### PR TITLE
Quad from int -> float64

### DIFF
--- a/tot/cdtp/dom/cdtp.go
+++ b/tot/cdtp/dom/cdtp.go
@@ -175,7 +175,7 @@ Quad is an array of quad vertices, x immediately followed by y for each point, p
 
 https://chromedevtools.github.io/devtools-protocol/tot/DOM/#type-Quad
 */
-type Quad [2]int
+type Quad [2]float64
 
 /*
 BoxModel represents the box model.


### PR DESCRIPTION
dom.GetBoxModel returns floats sometimes
Error: json: cannot unmarshal number 1143.96875 into Go struct field BoxModel.content of type int
Version: Google Chrome 65.0.3325.162

Some code to test is (added to your screenshot example):
```go
			// Get document nodeID
			var nodeID, elementID dom.NodeID
			if node := <-tab.DOM().GetDocument(&dom.GetDocumentParams{-1, false}); node.Err != nil {
				panic(node.Err)
			} else {
				nodeID = node.Root.NodeID
			}
			// get elementID
			if element := <-tab.DOM().QuerySelector(&dom.QuerySelectorParams{nodeID, "#fsr"}); element.Err != nil && element.NodeID != 0 {
				panic(element.Err)
			} else {
				elementID = element.NodeID
			}
			
			var model *dom.BoxModel
			if boxModel := <-tab.DOM().GetBoxModel(&dom.GetBoxModelParams{elementID, 0, ""}); boxModel.Err != nil {
				panic(boxModel.Err)
			} else {
				model = boxModel.Model
			}
```

I am not sure if this affects other code and/or tests in this library.