### PR TITLE
Add support for mocking socket timeouts

### DIFF
--- a/test/issue-101/Gopkg.lock
+++ b/test/issue-101/Gopkg.lock
@@ -67,12 +67,6 @@
   revision = "c98a00db7ec57537dd33b8bd868c4a75957ed5c2"
 
 [[projects]]
-  name = "github.com/sanity-io/litter"
-  packages = ["."]
-  revision = "ae543b7ba8fd6af63e4976198f146e1348ae53c1"
-  version = "v1.1.0"
-
-[[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
@@ -96,6 +90,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c0134ccfba10e9f29dccabfedc830d0911eac54ba25b61a8ff2c0bbd41083ca5"
+  inputs-digest = "1dc881fec2fd38d911b17e19bd02f0c7d5ad69a2131474cd0f26b870e97aae5f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/test/issue-101/main.go
+++ b/test/issue-101/main.go
@@ -57,7 +57,7 @@ func main() {
 		fmt.Printf(".")
 		time.Sleep(1 * time.Second)
 		cnt++
-		if cnt > 10 {
+		if cnt > 5 {
 			break
 		}
 	}

--- a/tot/mock.socket_test.go
+++ b/tot/mock.socket_test.go
@@ -153,7 +153,8 @@ func (socket *MockSocket) SendCommand(command socket.Commander) chan *socket.Res
 /*
 Stop is a Socketer implementation.
 */
-func (socket *MockSocket) Stop() {
+func (socket *MockSocket) Stop() error {
+	return nil
 }
 
 /*

--- a/tot/socket/interface.socketer.go
+++ b/tot/socket/interface.socketer.go
@@ -31,7 +31,7 @@ type Socketer interface {
 
 	// Stop signals the socket read loop to stop listening for data and close
 	// the websocket connection.
-	Stop()
+	Stop() error
 
 	// URL returns the URL of the websocket connection.
 	URL() *url.URL

--- a/tot/socket/mock.web_socketer_test.go
+++ b/tot/socket/mock.web_socketer_test.go
@@ -23,6 +23,7 @@ func NewMockWebsocket(socketURL *url.URL) (WebSocketer, error) {
 
 type MockChromeWebSocket struct {
 	mockResponses []*Response
+	sleep         time.Duration
 }
 
 func (socket *MockChromeWebSocket) Close() error { return nil }
@@ -47,6 +48,11 @@ func (socket *MockChromeWebSocket) ReadJSON(v interface{}) error {
 	var data interface{}
 	time.Sleep(time.Millisecond * 10)
 
+	if socket.sleep > 0 {
+		time.Sleep(socket.sleep)
+		socket.sleep = 0
+	}
+
 	if len(socket.mockResponses) > 0 {
 		data = socket.mockResponses[0]
 		socket.mockResponses = socket.mockResponses[1:]
@@ -62,6 +68,14 @@ func (socket *MockChromeWebSocket) ReadJSON(v interface{}) error {
 	log.Debugf("Mock ReadJSON(): returning mock data %s", jsonBytes)
 	err = json.Unmarshal(jsonBytes, &v)
 	return errs.Wrap(err, fmt.Sprintf("could not unmarshal %s", jsonBytes))
+}
+
+/*
+Sleep sets the sleep duration for the next ReadJSON call to replicate
+timeouts and delays.
+*/
+func (socket *MockChromeWebSocket) Sleep(duration time.Duration) {
+	socket.sleep = duration
 }
 
 /*

--- a/tot/socket/mock.web_socketer_test.go
+++ b/tot/socket/mock.web_socketer_test.go
@@ -26,7 +26,16 @@ type MockChromeWebSocket struct {
 	sleep         time.Duration
 }
 
-func (socket *MockChromeWebSocket) Close() error { return nil }
+func (socket *MockChromeWebSocket) Close() error {
+	socket.mockResponses = []*Response{
+		&Response{},
+		&Response{},
+		&Response{},
+		&Response{},
+		&Response{},
+	}
+	return nil
+}
 
 /*
 This method populates a queue of mock data that will be delivered to the
@@ -67,7 +76,10 @@ func (socket *MockChromeWebSocket) ReadJSON(v interface{}) error {
 	jsonBytes, err := json.Marshal(data)
 	log.Debugf("Mock ReadJSON(): returning mock data %s", jsonBytes)
 	err = json.Unmarshal(jsonBytes, &v)
-	return errs.Wrap(err, fmt.Sprintf("could not unmarshal %s", jsonBytes))
+	if nil != err {
+		return errs.Wrap(err, fmt.Sprintf("could not unmarshal %s", jsonBytes))
+	}
+	return nil
 }
 
 /*

--- a/tot/socket/socket.conner.go
+++ b/tot/socket/socket.conner.go
@@ -66,11 +66,14 @@ func (socket *Socket) Disconnect() error {
 	socket.Stop()
 	err := socket.conn.Close()
 	if nil != err {
-		err = errs.Wrap(err, "disconnect failed")
+		socket.listenErr.With(err)
 	}
 	socket.conn = nil
 	socket.connected = false
-	return err
+	if 0 == len(socket.listenErr) {
+		return nil
+	}
+	return socket.listenErr
 }
 
 /*

--- a/tot/socket/socket.socketer_test.go
+++ b/tot/socket/socket.socketer_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestNewSocket(t *testing.T) {
@@ -16,9 +17,23 @@ func TestNewSocket(t *testing.T) {
 
 func TestSocketDisconnect(t *testing.T) {
 	socketURL, _ := url.Parse("https://test:9222/TestSocketDisconnect")
-	socket := NewMock(socketURL)
-	if err := socket.Disconnect(); nil != err && "*errors.errorString" != reflect.TypeOf(err).String() {
+	mockSocket := NewMock(socketURL)
+	if err := mockSocket.Disconnect(); nil != err && "*errors.errorString" != reflect.TypeOf(err).String() {
 		t.Errorf("Socketer.Disconnect() must return an error or nil, %s found", reflect.TypeOf(err).String())
+	}
+
+	// Test the disconnect timeout
+	mockSocket = NewMock(socketURL)
+	mockSocket.Listen()
+	mockSocket.Conn().(*MockChromeWebSocket).Sleep(10 * time.Second)
+	start := time.Now()
+	//time.Sleep(1 * time.Second)
+	if err := mockSocket.Disconnect(); nil != err && "*errors.errorString" != reflect.TypeOf(err).String() {
+		t.Errorf("Socketer.Disconnect() must return an error or nil, %s found", reflect.TypeOf(err).String())
+	}
+	elapsed := time.Since(start)
+	if elapsed < 1*time.Second {
+		t.Errorf("Expected disconnect timeout in 1 seconds, %s elapsed", elapsed)
 	}
 }
 

--- a/tot/socket/socket.socketer_test.go
+++ b/tot/socket/socket.socketer_test.go
@@ -15,6 +15,20 @@ func TestNewSocket(t *testing.T) {
 	}
 }
 
+func TestCommandNotFound(t *testing.T) {
+	socketURL, _ := url.Parse("https://test:9222/TestCommandNotFound")
+	mockSocket := NewMock(socketURL)
+	mockSocket.Listen()
+	defer mockSocket.Stop()
+	mockSocket.Conn().(*MockChromeWebSocket).AddMockData(&Response{
+		ID:     999,
+		Error:  &Error{},
+		Method: "Some.methodError",
+		Result: []byte(`"Mock Command Result"`),
+	})
+	time.Sleep(1 * time.Second)
+}
+
 func TestSocketStop(t *testing.T) {
 	socketURL, _ := url.Parse("https://test:9222/TestSocketStop")
 	mockSocket := NewMock(socketURL)

--- a/tot/socket/socket.socketer_test.go
+++ b/tot/socket/socket.socketer_test.go
@@ -15,10 +15,20 @@ func TestNewSocket(t *testing.T) {
 	}
 }
 
+func TestSocketStop(t *testing.T) {
+	socketURL, _ := url.Parse("https://test:9222/TestSocketStop")
+	mockSocket := NewMock(socketURL)
+	mockSocket.Listen()
+	time.Sleep(1 * time.Second)
+	if err := mockSocket.Stop(); nil != err {
+		t.Errorf("Expected nil, got error: %v", err)
+	}
+}
+
 func TestSocketDisconnect(t *testing.T) {
 	socketURL, _ := url.Parse("https://test:9222/TestSocketDisconnect")
 	mockSocket := NewMock(socketURL)
-	if err := mockSocket.Disconnect(); nil != err && "*errors.errorString" != reflect.TypeOf(err).String() {
+	if err := mockSocket.Disconnect(); nil != err && "*errors.errorString" != reflect.TypeOf(err).String() && "errors.Err" != reflect.TypeOf(err).String() {
 		t.Errorf("Socketer.Disconnect() must return an error or nil, %s found", reflect.TypeOf(err).String())
 	}
 
@@ -27,8 +37,7 @@ func TestSocketDisconnect(t *testing.T) {
 	mockSocket.Listen()
 	mockSocket.Conn().(*MockChromeWebSocket).Sleep(10 * time.Second)
 	start := time.Now()
-	//time.Sleep(1 * time.Second)
-	if err := mockSocket.Disconnect(); nil != err && "*errors.errorString" != reflect.TypeOf(err).String() {
+	if err := mockSocket.Disconnect(); nil != err && "*errors.errorString" != reflect.TypeOf(err).String() && "errors.Err" != reflect.TypeOf(err).String() {
 		t.Errorf("Socketer.Disconnect() must return an error or nil, %s found", reflect.TypeOf(err).String())
 	}
 	elapsed := time.Since(start)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please make sure you view the 
contribution guidelines and fill out the fields below.
-->

### Change type

What types of changes does your code introduce to `go-chrome`?
<!--
Put an `x` in all the boxes that apply
-->

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] Other (please explain here)
  Adds unit-test support and a test for socket timeouts.

### Checklist
<!--
Put an `x` in all the boxes that apply. If you're unsure about any of them, don't hesitate to ask.
-->

* [x] I have read the [CONTRIBUTING](https://github.com/mkenney/go-chrome/blob/master/CONTRIBUTING.md) guidelines.
* [x] Lint and unit tests pass locally with my changes.
* [x] I have created tests which fail without the change (if possible) and prove my fix is effective or that my feature works.
* [x] I have added necessary documentation (if appropriate).

### What does this implement/fix? Please explain these changes.

https://github.com/mkenney/go-chrome/issues/103

### Does this close any currently open issues?
<!--
If so, please link to them here.
-->

https://github.com/mkenney/go-chrome/issues/103

### Any relevant logs, error output, etc?
<!--
If it’s long, please paste to https://pastebin.com/ or similar and insert the link here.
-->



### Any other comments?


