### PR TITLE
Added RemoveTab method to Chrome to allow removing of tab reference f…

### DIFF
--- a/tot/chrome.chromium.go
+++ b/tot/chrome.chromium.go
@@ -174,6 +174,19 @@ func (chrome *Chrome) GetTab(tabID string) (Tabber, error) {
 }
 
 /*
+RemoveTab implements Chromium.
+*/
+func (chrome *Chrome) RemoveTab(tab *Tab) {
+	tabs := make([]*Tab, 0)
+	for _, t := range chrome.Tabs() {
+		if t != tab {
+			tabs = append(tabs, t)
+		}
+	}
+	chrome.tabs = tabs
+}
+
+/*
 Launch implements Chromium.
 
 This implementation makes it's best effort to set a few sane default values if

--- a/tot/chrome.chromium.go
+++ b/tot/chrome.chromium.go
@@ -312,9 +312,10 @@ RemoveTab implements Chromium.
 */
 func (chrome *Chrome) RemoveTab(tab *Tab) {
 	tabs := make([]*Tab, 0)
-	for _, t := range chrome.Tabs() {
-		if t != tab {
-			tabs = append(tabs, t)
+	for k, t := range chrome.tabs {
+		if t == tab {
+			chrome.tabs = append(chrome.tabs[:k], chrome.tabs[k+1:]...)
+			break
 		}
 	}
 	chrome.tabs = tabs

--- a/tot/chrome.chromium.go
+++ b/tot/chrome.chromium.go
@@ -174,19 +174,6 @@ func (chrome *Chrome) GetTab(tabID string) (Tabber, error) {
 }
 
 /*
-RemoveTab implements Chromium.
-*/
-func (chrome *Chrome) RemoveTab(tab *Tab) {
-	tabs := make([]*Tab, 0)
-	for _, t := range chrome.Tabs() {
-		if t != tab {
-			tabs = append(tabs, t)
-		}
-	}
-	chrome.tabs = tabs
-}
-
-/*
 Launch implements Chromium.
 
 This implementation makes it's best effort to set a few sane default values if

--- a/tot/chrome.chromium.go
+++ b/tot/chrome.chromium.go
@@ -308,6 +308,19 @@ func (chrome *Chrome) Query(
 }
 
 /*
+RemoveTab implements Chromium.
+*/
+func (chrome *Chrome) RemoveTab(tab *Tab) {
+	tabs := make([]*Tab, 0)
+	for _, t := range chrome.Tabs() {
+		if t != tab {
+			tabs = append(tabs, t)
+		}
+	}
+	chrome.tabs = tabs
+}
+
+/*
 STDERR implements Chromium.
 */
 func (chrome *Chrome) STDERR() string {

--- a/tot/interface.chromium.go
+++ b/tot/interface.chromium.go
@@ -21,9 +21,6 @@ type Chromium interface {
 	// does not exist.
 	GetTab(tabID string) (tab Tabber, err error)
 
-	// RemoveTab removes tab reference from chrome tabs list.
-	RemoveTab(tab *Tab)
-
 	// DebuggingAddress returns the address that the remote debugging protocol
 	// is available on. Should return a sane default value such as '0.0.0.0'.
 	DebuggingAddress() string

--- a/tot/interface.chromium.go
+++ b/tot/interface.chromium.go
@@ -21,6 +21,9 @@ type Chromium interface {
 	// does not exist.
 	GetTab(tabID string) (tab Tabber, err error)
 
+	// RemoveTab removes tab reference from chrome tabs list.
+	RemoveTab(tab *Tab)
+
 	// DebuggingAddress returns the address that the remote debugging protocol
 	// is available on. Should return a sane default value such as '0.0.0.0'.
 	DebuggingAddress() string

--- a/tot/mock.chromium_test.go
+++ b/tot/mock.chromium_test.go
@@ -238,6 +238,19 @@ func (chrome *MockChrome) Query(
 }
 
 /*
+RemoveTab implements Chromium.
+*/
+func (chrome *Chrome) RemoveTab(tab *Tab) {
+	tabs := make([]*Tab, 0)
+	for _, t := range chrome.Tabs() {
+		if t != tab {
+			tabs = append(tabs, t)
+		}
+	}
+	chrome.tabs = tabs
+}
+
+/*
 STDERR implements Chromium.
 */
 func (chrome *MockChrome) STDERR() string {

--- a/tot/mock.chromium_test.go
+++ b/tot/mock.chromium_test.go
@@ -240,11 +240,12 @@ func (chrome *MockChrome) Query(
 /*
 RemoveTab implements Chromium.
 */
-func (chrome *Chrome) RemoveTab(tab *Tab) {
+func (chrome *MockChrome) RemoveTab(tab *Tab) {
 	tabs := make([]*Tab, 0)
-	for _, t := range chrome.Tabs() {
-		if t != tab {
-			tabs = append(tabs, t)
+	for k, t := range chrome.tabs {
+		if t == tab {
+			chrome.tabs = append(chrome.tabs[:k], chrome.tabs[k+1:]...)
+			break
 		}
 	}
 	chrome.tabs = tabs

--- a/tot/tab.tabber.go
+++ b/tot/tab.tabber.go
@@ -82,7 +82,12 @@ func (tab *Tab) Close() (interface{}, error) {
 		log.Warnf("%s: %s", result, err)
 		return nil, errs.Wrap(err, 0, fmt.Sprintf("close/%s query failed", tab.Data().ID))
 	}
-	tab.Chromium().RemoveTab(tab)
+	for k, t := range chrome.tabs {
+		if t == tab {
+			chrome.tabs = append(chrome.tabs[:k], chrome.tabs[k+1:]...)
+			break
+		}
+	}
 	return result, nil
 }
 

--- a/tot/tab.tabber.go
+++ b/tot/tab.tabber.go
@@ -82,12 +82,7 @@ func (tab *Tab) Close() (interface{}, error) {
 		log.Warnf("%s: %s", result, err)
 		return nil, errs.Wrap(err, 0, fmt.Sprintf("close/%s query failed", tab.Data().ID))
 	}
-	for k, t := range chrome.tabs {
-		if t == tab {
-			chrome.tabs = append(chrome.tabs[:k], chrome.tabs[k+1:]...)
-			break
-		}
-	}
+	tab.Chromium().RemoveTab(tab)
 	return result, nil
 }
 

--- a/tot/tab.tabber.go
+++ b/tot/tab.tabber.go
@@ -82,7 +82,7 @@ func (tab *Tab) Close() (interface{}, error) {
 		log.Warnf("%s: %s", result, err)
 		return nil, errs.Wrap(err, 0, fmt.Sprintf("close/%s query failed", tab.Data().ID))
 	}
-
+	tab.Chromium().RemoveTab(tab)
 	return result, nil
 }
 


### PR DESCRIPTION
…rom slice via tab.Close

### Change type

What types of changes does your code introduce to `go-chrome`?

* [X ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Other (please explain here)

### Checklist

* [X ] I have read the [CONTRIBUTING](https://github.com/mkenney/go-chrome/blob/master/CONTRIBUTING.md) guidelines.
* [ ] Lint and unit tests pass locally with my changes.
* [ ] I have created tests which fail without the change (if possible) and prove my fix is effective or that my feature works.
* [ ] I have added necessary documentation (if appropriate).

### What does this implement/fix? Please explain these changes.

This is my (naive) attempt to solve the issue of not removing references to open tabs in the main Chrome structs Tabs list.

Since we aren't able to access `chrome.tabs` directly, a RemoveTab method was created which simply receives a tab, iterates over chrome.tabs and updates the tabs slice w/o given tab.


### Does this close any currently open issues?
https://github.com/mkenney/go-chrome/issues/110



### Any relevant logs, error output, etc?
n/a



### Any other comments?

Just wanted to give my attempt at solving this issues -- please feel free to amend or ignore as necessary! 👍 
