### PR TITLE
124: enable handling socket errors

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -37,5 +37,4 @@ for dir in $(go list ./... | grep -v vendor); do
     fi
 done
 
-cat coverage.txt
 exit $exit_code

--- a/.travis.sh
+++ b/.travis.sh
@@ -37,4 +37,5 @@ for dir in $(go list ./... | grep -v vendor); do
     fi
 done
 
+cat coverage.txt
 exit $exit_code

--- a/_examples/detect-socket-failure/README.md
+++ b/_examples/detect-socket-failure/README.md
@@ -1,0 +1,6 @@
+# Detect socket failure
+
+* https://github.com/mkenney/go-chrome/issues/124
+* https://github.com/mkenney/go-chrome/pull/125
+
+To test, start a remote chrome instance available at localhost, and run this script. While the script is waiting, stop chrome and wait for the script to exit gracefully.

--- a/_examples/detect-socket-failure/main.go
+++ b/_examples/detect-socket-failure/main.go
@@ -31,6 +31,7 @@ func main() {
 		fmt.Printf("%+v\n", enableResult.Err)
 	}
 
+	// While this is waiting, stop chrome
 	for err := range tab.Socket().Errors() {
 		fmt.Printf("%+v\n", err)
 		if e, ok := err.(errs.Err); ok {

--- a/_examples/detect-socket-failure/main.go
+++ b/_examples/detect-socket-failure/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+
+	errs "github.com/bdlm/errors"
+	"github.com/mkenney/go-chrome/codes"
+	chrome "github.com/mkenney/go-chrome/tot"
+)
+
+func main() {
+	browser := chrome.New(
+		&chrome.Flags{
+			"addr":                     "0.0.0.0",
+			"remote-debugging-address": "0.0.0.0",
+			"remote-debugging-port":    9222,
+		},
+		"",
+		"",
+		"",
+		"",
+	)
+
+	tab, err := browser.NewTab("https://www.google.com")
+	if nil != err {
+		fmt.Printf("%+v\n", err)
+	}
+
+	// Enable Page events for this tab.
+	if enableResult := <-tab.Page().Enable(); nil != enableResult.Err {
+		fmt.Printf("%+v\n", enableResult.Err)
+	}
+
+	for err := range tab.Socket().Errors() {
+		fmt.Printf("%+v\n", err)
+		if e, ok := err.(errs.Err); ok {
+			if codes.SocketPanic == e.Code() {
+				return
+			}
+		}
+	}
+}

--- a/_examples/detect-socket-failure/main.go
+++ b/_examples/detect-socket-failure/main.go
@@ -14,11 +14,7 @@ func main() {
 			"addr":                     "0.0.0.0",
 			"remote-debugging-address": "0.0.0.0",
 			"remote-debugging-port":    9222,
-		},
-		"",
-		"",
-		"",
-		"",
+		}, "", "", "", "",
 	)
 
 	tab, err := browser.NewTab("https://www.google.com")

--- a/_examples/get-dom-node/main.go
+++ b/_examples/get-dom-node/main.go
@@ -18,21 +18,21 @@ func main() {
 		// See https://developers.google.com/web/updates/2017/04/headless-chrome#cli
 		// for details about startup flags
 		&chrome.Flags{
-			"addr":               "localhost",
-			"disable-extensions": nil,
-			"disable-gpu":        nil,
-			"headless":           nil,
-			"hide-scrollbars":    nil,
-			"no-first-run":       nil,
-			"no-sandbox":         nil,
-			"port":               9222,
+			"addr":                     "localhost",
+			"disable-extensions":       nil,
+			"disable-gpu":              nil,
+			"headless":                 nil,
+			"hide-scrollbars":          nil,
+			"no-first-run":             nil,
+			"no-sandbox":               nil,
+			"port":                     9222,
 			"remote-debugging-address": "0.0.0.0",
 			"remote-debugging-port":    9222,
 		},
 		"/usr/bin/google-chrome", // Path to Chromeium binary
-		"/tmp",      // Set the Chromium working directory
-		"/dev/null", // Ignore internal Chromium output, set to empty string for os.Stdout
-		"/dev/null", // Ignore internal Chromium errors, set to empty string for os.Stderr
+		"/tmp",                   // Set the Chromium working directory
+		"/dev/null",              // Ignore internal Chromium output, set to empty string for os.Stdout
+		"/dev/null",              // Ignore internal Chromium errors, set to empty string for os.Stderr
 	)
 
 	// Start the chrome process.

--- a/codes/codes.go
+++ b/codes/codes.go
@@ -10,24 +10,120 @@ const (
 	Unspecified std.Code = iota + 1000
 	// Unknown - 1001: An unspecified error occurred.
 	Unknown
+	// MockErr - 1002: An error occurred in a test mock.
+	MockErr
 )
-const (
-	////////////////////////////////////////////////////////////////////////////
-	// Socket errors
-	////////////////////////////////////////////////////////////////////////////
 
-	// SocketPanic - 2000: A panic occurred while reading from a websocket
-	SocketPanic std.Code = iota + 2000
-	// SocketReadFailed - 2001: A failure occurred while reading from a websocket
+////////////////////////////////////////////////////////////////////////////
+// Chrome errors
+////////////////////////////////////////////////////////////////////////////
+const (
+	// ChromeCannotOpenStderr - 2000: Cannot open error output file.
+	ChromeCannotOpenStderr std.Code = iota + 2000
+	// ChromeCannotOpenStdout - 2001: Cannot open standard output file.
+	ChromeCannotOpenStdout
+	// ChromeExitTimeout - 2002: Error waiting for process exit.
+	ChromeExitTimeout
+	// ChromeInvalidWorkdir - 2003: Cannot create working directory.
+	ChromeInvalidWorkdir
+	// ChromeQueryFailed - 2004: Chrome.Query() returned an error.
+	ChromeQueryFailed
+	// ChromeSigintFailed - 2005: Chromium process interrupt failed.
+	ChromeSigintFailed
+	// ChromeStartTimeout - 2006: Chromium took too long to start.
+	ChromeStartTimeout
+	// ChromeTabNotFound - 2007: Chromium tab not found.
+	ChromeTabNotFound
+	// ChromeVersionQueryFailed - 2008: Chromium version query failed.
+	ChromeVersionQueryFailed
+)
+
+////////////////////////////////////////////////////////////////////////////
+// Flag errors
+////////////////////////////////////////////////////////////////////////////
+const (
+	// FlagDoesNotExist - 3000: The specified argument does not exist.
+	FlagDoesNotExist std.Code = iota + 3000
+	// FlagTypeInvalid - 3001: Invalid data type for the specified argument.
+	FlagTypeInvalid
+)
+
+////////////////////////////////////////////////////////////////////////////
+// Tab errors
+////////////////////////////////////////////////////////////////////////////
+const (
+
+	// TabQueryFailed - 4000: The new tab query failed.
+	TabQueryFailed std.Code = iota + 4000
+	// TabURLInvalid - 4001: Invalid URL passed to NewTab.
+	TabURLInvalid
+	// TabWebsocketURLInvalid - 4002: Invalid websocket URL.
+	TabWebsocketURLInvalid
+)
+
+////////////////////////////////////////////////////////////////////////////
+// Socket errors
+////////////////////////////////////////////////////////////////////////////
+const (
+	// SocketCloseFailed - 5000: A failure occurred while closing a websocket.
+	SocketCloseFailed std.Code = iota + 5000
+	// SocketReadFailed - 5001: A failure occurred while reading from a websocket.
 	SocketReadFailed
-	// SocketCloseFailed - 2002: A failure occurred while closing a websocket
-	SocketCloseFailed
+	// SocketCmdHandlerNotFound - 5002: Command handler not found.
+	SocketCmdHandlerNotFound
+	// SocketReadFailed - 5002: Attempted to add a duplicate handler for event.
+	SocketDuplicateEventHandler
+	// SocketEventHandlerNotFound - 5003: No event listeners found for an event.
+	SocketEventHandlerNotFound
+	// SocketConnectFailed - 5003: Connect() failed while creating socket.
+	SocketConnectFailed
+	// SocketNotConnected - 5003: Not connected.
+	SocketNotConnected
+	// SocketWriteFailed - 5003: Socket write failed.
+	SocketWriteFailed
+	// SocketPanic - 5003: A panic occurred while reading from a websocket.
+	SocketPanic
+)
+
+////////////////////////////////////////////////////////////////////////////
+// Webocket errors
+////////////////////////////////////////////////////////////////////////////
+const (
+	// WebsocketConnectFailed - 6000: Websocket connection failed.
+	WebsocketConnectFailed std.Code = iota + 6000
+	// WebsocketNotConnected - 6001: Websocket not connected.
+	WebsocketNotConnected
+	// WebsocketPanic - 5002: A panic occurred while reading from a websocket.
+	WebsocketPanic
 )
 
 func init() {
-	errs.Codes[Unspecified] = errs.ErrCode{Ext: "An unknown error occurred", Int: "An unknown error occurred", HTTP: 500}
-	errs.Codes[Unknown] = errs.ErrCode{Ext: "An unknown error occurred", Int: "An unspecified error occurred", HTTP: 500}
-	errs.Codes[SocketPanic] = errs.ErrCode{Ext: "An unknown error occurred", Int: "A panic occurred while reading from a websocket", HTTP: 500}
-	errs.Codes[SocketReadFailed] = errs.ErrCode{Ext: "An unknown error occurred", Int: "A failure occurred while reading from a websocket", HTTP: 500}
-	errs.Codes[SocketCloseFailed] = errs.ErrCode{Ext: "An unknown error occurred", Int: "A failure occurred while closing a websocket", HTTP: 500}
+	errs.Codes[Unspecified] = errs.ErrCode{Int: "The error code was unspecified", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[Unknown] = errs.ErrCode{Int: "An unspecified error occurred", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[MockErr] = errs.ErrCode{Int: "An error occurred in a test mock", Ext: "An unknown error occurred", HTTP: 500}
+
+	errs.Codes[ChromeCannotOpenStderr] = errs.ErrCode{Int: "Cannot open error output file", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[ChromeCannotOpenStdout] = errs.ErrCode{Int: "Cannot open standard output file", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[ChromeExitTimeout] = errs.ErrCode{Int: "Error waiting for process exit", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[ChromeInvalidWorkdir] = errs.ErrCode{Int: "Cannot create working directory", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[ChromeQueryFailed] = errs.ErrCode{Int: "Chrome.Query() returned an error", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[ChromeSigintFailed] = errs.ErrCode{Int: "Chromium process interrupt failed", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[ChromeStartTimeout] = errs.ErrCode{Int: "Chromium took too long to start", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[ChromeTabNotFound] = errs.ErrCode{Int: "Chromium tab not found", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[ChromeVersionQueryFailed] = errs.ErrCode{Int: "Chromium version query failed", Ext: "An unknown error occurred", HTTP: 500}
+
+	errs.Codes[FlagDoesNotExist] = errs.ErrCode{Int: "The specified argument does not exist", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[FlagTypeInvalid] = errs.ErrCode{Int: "Invalid data type for the specified argument", Ext: "An unknown error occurred", HTTP: 500}
+
+	errs.Codes[TabQueryFailed] = errs.ErrCode{Int: "The new tab query failed", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[TabURLInvalid] = errs.ErrCode{Int: "Invalid URL passed to NewTab", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[TabWebsocketURLInvalid] = errs.ErrCode{Int: "Invalid websocket URL", Ext: "An unknown error occurred", HTTP: 500}
+
+	errs.Codes[SocketCloseFailed] = errs.ErrCode{Int: "A failure occurred while closing a websocket", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[SocketReadFailed] = errs.ErrCode{Int: "A failure occurred while reading from a websocket", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[SocketPanic] = errs.ErrCode{Int: "A panic occurred while reading from a websocket", Ext: "An unknown error occurred", HTTP: 500}
+
+	errs.Codes[WebsocketConnectFailed] = errs.ErrCode{Int: "Websocket connection failed", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[WebsocketNotConnected] = errs.ErrCode{Int: "Websocket not connected", Ext: "An unknown error occurred", HTTP: 500}
+	errs.Codes[WebsocketPanic] = errs.ErrCode{Int: "A panic occurred while reading from a websocket", Ext: "An unknown error occurred", HTTP: 500}
 }

--- a/codes/codes.go
+++ b/codes/codes.go
@@ -18,7 +18,9 @@ const (
 
 	// SocketPanic - 2000: A panic occurred while reading from a websocket
 	SocketPanic std.Code = iota + 2000
+	// SocketReadFailed - 2001: A failure occurred while reading from a websocket
 	SocketReadFailed
+	// SocketCloseFailed - 2002: A failure occurred while closing a websocket
 	SocketCloseFailed
 )
 
@@ -26,4 +28,6 @@ func init() {
 	errs.Codes[Unspecified] = errs.ErrCode{Ext: "An unknown error occurred", Int: "An unknown error occurred", HTTP: 500}
 	errs.Codes[Unknown] = errs.ErrCode{Ext: "An unknown error occurred", Int: "An unspecified error occurred", HTTP: 500}
 	errs.Codes[SocketPanic] = errs.ErrCode{Ext: "An unknown error occurred", Int: "A panic occurred while reading from a websocket", HTTP: 500}
+	errs.Codes[SocketPanic] = errs.ErrCode{Ext: "An unknown error occurred", Int: "A failure occurred while reading from a websocket", HTTP: 500}
+	errs.Codes[SocketPanic] = errs.ErrCode{Ext: "An unknown error occurred", Int: "A failure occurred while closing a websocket", HTTP: 500}
 }

--- a/codes/codes.go
+++ b/codes/codes.go
@@ -1,0 +1,29 @@
+package codes
+
+import (
+	errs "github.com/bdlm/errors"
+	std "github.com/bdlm/std/error"
+)
+
+const (
+	// Unspecified - 1000: The error code was unspecified
+	Unspecified std.Code = iota + 1000
+	// Unknown - 1001: An unspecified error occurred.
+	Unknown
+)
+const (
+	////////////////////////////////////////////////////////////////////////////
+	// Socket errors
+	////////////////////////////////////////////////////////////////////////////
+
+	// SocketPanic - 2000: A panic occurred while reading from a websocket
+	SocketPanic std.Code = iota + 2000
+	SocketReadFailed
+	SocketCloseFailed
+)
+
+func init() {
+	errs.Codes[Unspecified] = errs.ErrCode{Ext: "An unknown error occurred", Int: "An unknown error occurred", HTTP: 500}
+	errs.Codes[Unknown] = errs.ErrCode{Ext: "An unknown error occurred", Int: "An unspecified error occurred", HTTP: 500}
+	errs.Codes[SocketPanic] = errs.ErrCode{Ext: "An unknown error occurred", Int: "A panic occurred while reading from a websocket", HTTP: 500}
+}

--- a/codes/codes.go
+++ b/codes/codes.go
@@ -28,6 +28,6 @@ func init() {
 	errs.Codes[Unspecified] = errs.ErrCode{Ext: "An unknown error occurred", Int: "An unknown error occurred", HTTP: 500}
 	errs.Codes[Unknown] = errs.ErrCode{Ext: "An unknown error occurred", Int: "An unspecified error occurred", HTTP: 500}
 	errs.Codes[SocketPanic] = errs.ErrCode{Ext: "An unknown error occurred", Int: "A panic occurred while reading from a websocket", HTTP: 500}
-	errs.Codes[SocketPanic] = errs.ErrCode{Ext: "An unknown error occurred", Int: "A failure occurred while reading from a websocket", HTTP: 500}
-	errs.Codes[SocketPanic] = errs.ErrCode{Ext: "An unknown error occurred", Int: "A failure occurred while closing a websocket", HTTP: 500}
+	errs.Codes[SocketReadFailed] = errs.ErrCode{Ext: "An unknown error occurred", Int: "A failure occurred while reading from a websocket", HTTP: 500}
+	errs.Codes[SocketCloseFailed] = errs.ErrCode{Ext: "An unknown error occurred", Int: "A failure occurred while closing a websocket", HTTP: 500}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.5'
+services:
+    chrome:
+        container_name: chrome
+        hostname: chrome
+        image: mkenney/chromium-headless:latest
+        ports:
+            - 9222:9222
+        entrypoint: sh
+        command:
+            - "-cexu"
+            - "/usr/bin/google-chrome --addr=localhost --port=9222 --remote-debugging-port=9222 --remote-debugging-address=0.0.0.0 --disable-extensions --disable-gpu --headless --hide-scrollbars --no-first-run --no-sandbox"

--- a/tot/chrome.chromium_flags.go
+++ b/tot/chrome.chromium_flags.go
@@ -7,6 +7,7 @@ import (
 
 	errs "github.com/bdlm/errors"
 	"github.com/bdlm/log"
+	"github.com/mkenney/go-chrome/codes"
 )
 
 /*
@@ -21,7 +22,7 @@ func (flags Flags) Get(arg string) (interface{}, error) {
 	var values interface{}
 	var err error
 	if !flags.Has(arg) {
-		err = errs.New(0, fmt.Sprintf("The specified argument '%s' does not exist", arg))
+		err = errs.New(codes.FlagDoesNotExist, fmt.Sprintf("The specified argument '%s' does not exist", arg))
 	} else {
 		values = flags[arg]
 	}
@@ -84,7 +85,7 @@ func (flags Flags) Set(arg string, value interface{}) (err error) {
 		case string:
 			flags[arg] = value
 		default:
-			return errs.New(0, fmt.Sprintf("Invalid data type '%T' for argument %s: %+v", value, arg, value))
+			return errs.New(codes.FlagTypeInvalid, fmt.Sprintf("Invalid data type '%T' for argument %s: %+v", value, arg, value))
 		}
 	}
 

--- a/tot/mock.chromium_test.go
+++ b/tot/mock.chromium_test.go
@@ -8,6 +8,7 @@ import (
 
 	errs "github.com/bdlm/errors"
 	"github.com/bdlm/log"
+	"github.com/mkenney/go-chrome/codes"
 )
 
 /*
@@ -143,7 +144,7 @@ func (chrome *MockChrome) GetTab(tabID string) (Tabber, error) {
 			return tab, nil
 		}
 	}
-	err = errs.New(0, fmt.Sprintf("tab '%s' not found", tabID))
+	err = errs.New(codes.MockErr, fmt.Sprintf("tab '%s' not found", tabID))
 	return tab, err
 }
 
@@ -182,7 +183,7 @@ func (chrome *MockChrome) Launch() error {
 			0600,
 		)
 		if err != nil {
-			return errs.Wrap(err, 0, fmt.Sprintf("cannot open error output file '%s'", chrome.STDERR()))
+			return errs.Wrap(err, codes.MockErr, fmt.Sprintf("cannot open error output file '%s'", chrome.STDERR()))
 		}
 	}
 
@@ -195,7 +196,7 @@ func (chrome *MockChrome) Launch() error {
 			0600,
 		)
 		if err != nil {
-			return errs.Wrap(err, 0, fmt.Sprintf("cannot open standard output file '%s'", chrome.STDOUT()))
+			return errs.Wrap(err, codes.MockErr, fmt.Sprintf("cannot open standard output file '%s'", chrome.STDOUT()))
 		}
 	}
 
@@ -203,7 +204,7 @@ func (chrome *MockChrome) Launch() error {
 	if nil != err {
 		chrome.stdOUTFile.Close()
 		chrome.stdERRFile.Close()
-		return errs.Wrap(err, 0, "error starting chrome")
+		return errs.Wrap(err, codes.MockErr, "error starting chrome")
 	}
 
 	return nil
@@ -305,7 +306,7 @@ func (chrome *MockChrome) NewTab(uri string) (*Tab, error) {
 	}
 	targetURL, err := url.Parse(uri)
 	if nil != err {
-		return nil, errs.Wrap(err, 0, "invalid URL")
+		return nil, errs.Wrap(err, codes.MockErr, "invalid URL")
 	}
 
 	tab := &Tab{

--- a/tot/mock.socket_test.go
+++ b/tot/mock.socket_test.go
@@ -59,6 +59,7 @@ Socket is a Socketer implementation.
 type MockSocket struct {
 	url       *url.URL
 	commandID int
+	errCh     chan error
 
 	// Protocol interfaces for the API.
 	accessibility        *socket.AccessibilityProtocol
@@ -117,6 +118,10 @@ func (socket *MockSocket) CurCommandID() int {
 	return id
 }
 
+func (socket *MockSocket) Errors() chan error {
+	return socket.errCh
+}
+
 /*
 Listen starts the socket read loop and delivers messages to handleResponse() and
 handleEvent() as appropriate.
@@ -153,8 +158,7 @@ func (socket *MockSocket) SendCommand(command socket.Commander) chan *socket.Res
 /*
 Stop is a Socketer implementation.
 */
-func (socket *MockSocket) Stop() error {
-	return nil
+func (socket *MockSocket) Stop() {
 }
 
 /*

--- a/tot/mock.socket_test.go
+++ b/tot/mock.socket_test.go
@@ -8,7 +8,8 @@ import (
 
 func NewMockSocket(url *url.URL) *MockSocket {
 	mockSocket := &MockSocket{
-		url: url,
+		url:   url,
+		errCh: make(chan error, 3),
 	}
 
 	mockSocket.accessibility = &socket.AccessibilityProtocol{Socket: mockSocket}

--- a/tot/socket/interface.socketer.go
+++ b/tot/socket/interface.socketer.go
@@ -15,6 +15,9 @@ type Socketer interface {
 	// CurCommandID returns the latest command ID.
 	CurCommandID() int
 
+	// Errors returns a channel of errors
+	Errors() chan error
+
 	// Listen starts the socket read loop and delivers messages to
 	// HandleCommand() and HandleEvent() as appropriate.
 	Listen()
@@ -31,7 +34,7 @@ type Socketer interface {
 
 	// Stop signals the socket read loop to stop listening for data and close
 	// the websocket connection.
-	Stop() error
+	Stop()
 
 	// URL returns the URL of the websocket connection.
 	URL() *url.URL

--- a/tot/socket/mock.web_socketer_test.go
+++ b/tot/socket/mock.web_socketer_test.go
@@ -8,6 +8,7 @@ import (
 
 	errs "github.com/bdlm/errors"
 	"github.com/bdlm/log"
+	"github.com/mkenney/go-chrome/codes"
 )
 
 /*
@@ -71,7 +72,7 @@ func (socket *MockChromeWebSocket) ReadJSON(v interface{}) error {
 	log.Debugf("Mock ReadJSON(): returning mock data %s", jsonBytes)
 	err := json.Unmarshal(jsonBytes, &v)
 	if nil != err {
-		return errs.Wrap(err, 0, fmt.Sprintf("could not unmarshal %s", jsonBytes))
+		return errs.Wrap(err, codes.MockErr, fmt.Sprintf("could not unmarshal %s", jsonBytes))
 	}
 	return nil
 }

--- a/tot/socket/socket.conner.go
+++ b/tot/socket/socket.conner.go
@@ -5,6 +5,7 @@ import (
 
 	errs "github.com/bdlm/errors"
 	"github.com/bdlm/log"
+	"github.com/mkenney/go-chrome/codes"
 )
 
 /*
@@ -75,14 +76,11 @@ func (socket *Socket) Disconnect() error {
 	socket.Stop()
 	err := socket.conn.Close()
 	if nil != err {
-		socket.listenErr.With(err, "could not close socket connection")
+		err = errs.Wrap(err, codes.SocketCloseFailed, "could not close socket connection")
 	}
 	socket.conn = nil
 	socket.connected = false
-	if 0 == len(socket.listenErr) {
-		return nil
-	}
-	return socket.listenErr
+	return err
 }
 
 /*

--- a/tot/socket/socket.conner.go
+++ b/tot/socket/socket.conner.go
@@ -42,7 +42,7 @@ func (socket *Socket) Connect() error {
 			"socketID": socket.socketID,
 		}).Debug("received error")
 		socket.connected = false
-		return errs.Wrap(err, 0, "Connect() failed while creating socket")
+		return errs.Wrap(err, codes.SocketEventHandlerNotFound, "Connect() failed while creating socket")
 	}
 
 	socket.conn = websocket
@@ -91,12 +91,12 @@ ReadJSON is a Conner implementation.
 func (socket *Socket) ReadJSON(v interface{}) error {
 	err := socket.Connect()
 	if nil != err {
-		return errs.Wrap(err, 0, "not connected")
+		return errs.Wrap(err, codes.SocketNotConnected, "not connected")
 	}
 
 	err = socket.conn.ReadJSON(&v)
 	if nil != err {
-		return errs.Wrap(err, 0, "socket read failed")
+		return errs.Wrap(err, codes.SocketReadFailed, "socket read failed")
 	}
 
 	return nil
@@ -110,12 +110,12 @@ WriteJSON is a Conner implementation.
 func (socket *Socket) WriteJSON(v interface{}) error {
 	err := socket.Connect()
 	if nil != err {
-		return errs.Wrap(err, 0, "not connected")
+		return errs.Wrap(err, codes.SocketNotConnected, "not connected")
 	}
 
 	err = socket.conn.WriteJSON(v)
 	if nil != err {
-		return errs.Wrap(err, 0, "socket write failed")
+		return errs.Wrap(err, codes.SocketWriteFailed, "socket write failed")
 	}
 
 	return nil

--- a/tot/socket/socket.conner.go
+++ b/tot/socket/socket.conner.go
@@ -31,16 +31,12 @@ func (socket *Socket) Connect() error {
 		return nil
 	}
 
-	log.WithFields(log.Fields{
-		"socketID": socket.socketID,
-		"url":      socket.url.String(),
-	}).Debug("connecting")
+	log.WithFields(log.Fields{"socketID": socket.socketID, "url": socket.url.String()}).
+		Debug("connecting")
 	websocket, err := socket.newSocket(socket.url)
 	if nil != err {
-		log.WithFields(log.Fields{
-			"error":    err.Error(),
-			"socketID": socket.socketID,
-		}).Debug("received error")
+		log.WithFields(log.Fields{"error": err.Error(), "socketID": socket.socketID}).
+			Debug("received error")
 		socket.connected = false
 		return errs.Wrap(err, codes.SocketEventHandlerNotFound, "Connect() failed while creating socket")
 	}
@@ -48,10 +44,8 @@ func (socket *Socket) Connect() error {
 	socket.conn = websocket
 	socket.connected = true
 
-	log.WithFields(log.Fields{
-		"socketID": socket.socketID,
-		"url":      socket.url.String(),
-	}).Debug("connection established")
+	log.WithFields(log.Fields{"socketID": socket.socketID, "url": socket.url.String()}).
+		Debug("connection established")
 	return nil
 }
 

--- a/tot/socket/socket.event_handler_mapper.go
+++ b/tot/socket/socket.event_handler_mapper.go
@@ -6,6 +6,7 @@ import (
 
 	errs "github.com/bdlm/errors"
 	"github.com/bdlm/log"
+	"github.com/mkenney/go-chrome/codes"
 )
 
 /*
@@ -44,7 +45,7 @@ func (stack *EventHandlerMap) Add(
 	}
 	for _, hndl := range handlers {
 		if hndl == handler {
-			return errs.New(0, fmt.Sprintf("Attempted to add a duplicate handler for event '%s'", handler.Name()))
+			return errs.New(codes.SocketDuplicateEventHandler, fmt.Sprintf("Attempted to add a duplicate handler for event '%s'", handler.Name()))
 		}
 	}
 
@@ -78,7 +79,7 @@ func (stack *EventHandlerMap) Get(
 	if handlers, ok := stack.stack[name]; ok {
 		return handlers, nil
 	}
-	return nil, errs.New(0, fmt.Sprintf("No event listeners found for %s", name))
+	return nil, errs.New(codes.SocketDuplicateEventHandler, fmt.Sprintf("No event listeners found for %s", name))
 }
 
 /*
@@ -107,7 +108,7 @@ func (stack *EventHandlerMap) Remove(
 			return nil
 		}
 	}
-	return errs.New(0, fmt.Sprintf("Could not remove handler for '%s': not found", handler.Name()))
+	return errs.New(codes.SocketEventHandlerNotFound, fmt.Sprintf("Could not remove handler for '%s': not found", handler.Name()))
 }
 
 /*

--- a/tot/socket/socket.event_handler_mapper.go
+++ b/tot/socket/socket.event_handler_mapper.go
@@ -49,9 +49,8 @@ func (stack *EventHandlerMap) Add(
 		}
 	}
 
-	log.WithFields(log.Fields{
-		"event": handler.Name(),
-	}).Debug("Adding event handler")
+	log.WithFields(log.Fields{"event": handler.Name()}).
+		Debug("Adding event handler")
 	handlers = append(handlers, handler)
 	stack.Set(handler.Name(), handlers)
 	return nil

--- a/tot/socket/socket.socketer.go
+++ b/tot/socket/socket.socketer.go
@@ -104,12 +104,10 @@ type Socket struct {
 	connected    bool
 	errCh        chan error
 	handlers     EventHandlerMapper
-	lastErr      error
 	listenCh     chan bool
 	listening    bool
 	mux          *sync.Mutex
 	newSocket    func(socketURL *url.URL) (WebSocketer, error)
-	socketErr    error
 	socketID     int
 	url          *url.URL
 

--- a/tot/socket/socket.socketer.go
+++ b/tot/socket/socket.socketer.go
@@ -182,7 +182,7 @@ connection.
 func (socket *Socket) handleResponse(response *Response) {
 	// Log a message on error
 	if command, err := socket.commands.Get(response.ID); nil != err {
-		err = errs.Wrap(err, 0, fmt.Sprintf("command #%d not found", response.ID))
+		err = errs.Wrap(err, codes.SocketCmdHandlerNotFound, fmt.Sprintf("command #%d not found", response.ID))
 		log.WithFields(log.Fields{
 			"error":    err,
 			"result":   response.Result,
@@ -257,7 +257,7 @@ func (socket *Socket) handleUnknown(
 
 	// Check for a command listening for ID 0
 	if command, err = socket.commands.Get(response.ID); nil != err {
-		err = errs.Wrap(err, 0, fmt.Sprintf("command #%d not found", response.ID))
+		err = errs.Wrap(err, codes.SocketCmdHandlerNotFound, fmt.Sprintf("command #%d not found", response.ID))
 		if nil != response.Error && 0 != response.Error.Code {
 			err = err.(errs.Err).With(response.Error, err.Error())
 		}

--- a/tot/socket/socket.socketer.go
+++ b/tot/socket/socket.socketer.go
@@ -330,8 +330,6 @@ func (socket *Socket) listen(errCh chan error) {
 			log.WithFields(log.Fields{
 				"socketID": socket.socketID,
 			}).Error(err)
-
-			errCh <- err
 		}
 		if 0 == response.ID &&
 			"" == response.Method &&

--- a/tot/socket/socket.socketer.go
+++ b/tot/socket/socket.socketer.go
@@ -20,7 +20,7 @@ func New(url *url.URL) *Socket {
 	socket := &Socket{
 		commandIDMux: &sync.Mutex{},
 		commands:     NewCommandMap(),
-		errCh:        make(chan error, 1),
+		errCh:        make(chan error, 3),
 		handlers:     NewEventHandlerMap(),
 		mux:          &sync.Mutex{},
 		newSocket:    NewWebsocket,

--- a/tot/socket/socket.socketer_test.go
+++ b/tot/socket/socket.socketer_test.go
@@ -34,9 +34,7 @@ func TestSocketStop(t *testing.T) {
 	mockSocket := NewMock(socketURL)
 	mockSocket.Listen()
 	time.Sleep(1 * time.Second)
-	if err := mockSocket.Stop(); nil != err {
-		t.Errorf("Expected nil, got error: %v", err)
-	}
+	mockSocket.Stop()
 }
 
 func TestSocketDisconnect(t *testing.T) {

--- a/tot/socket/socket.web_socketer.go
+++ b/tot/socket/socket.web_socketer.go
@@ -9,6 +9,7 @@ import (
 	errs "github.com/bdlm/errors"
 	"github.com/bdlm/log"
 	"github.com/gorilla/websocket"
+	"github.com/mkenney/go-chrome/codes"
 )
 
 /*
@@ -27,7 +28,7 @@ func NewWebsocket(socketURL *url.URL) (WebSocketer, error) {
 
 	websocket, response, err := dialer.Dial(socketURL.String(), header)
 	if err != nil {
-		return nil, errs.Wrap(err, 0, fmt.Sprintf(
+		return nil, errs.Wrap(err, codes.WebsocketConnectFailed, fmt.Sprintf(
 			"%s websocket connection failed",
 			socketURL.String(),
 		))
@@ -76,7 +77,7 @@ Response{} pointer with the AddMockData() method.
 */
 func (socket *ChromeWebSocket) ReadJSON(v interface{}) error {
 	if nil == socket.conn {
-		return errs.New(0, "not connected")
+		return errs.New(codes.WebsocketNotConnected, "not connected")
 	}
 	return socket.conn.ReadJSON(&v)
 }
@@ -88,7 +89,7 @@ WriteJSON is a WebSocketer implementation.
 */
 func (socket *ChromeWebSocket) WriteJSON(v interface{}) error {
 	if nil == socket.conn {
-		return errs.New(0, "not connected")
+		return errs.New(codes.WebsocketNotConnected, "not connected")
 	}
 	tmp, _ := json.Marshal(v)
 	if len(tmp) > 1*1024*1024 {

--- a/tot/socket/socket.web_socketer.go
+++ b/tot/socket/socket.web_socketer.go
@@ -33,10 +33,8 @@ func NewWebsocket(socketURL *url.URL) (WebSocketer, error) {
 			socketURL.String(),
 		))
 	}
-	log.WithFields(log.Fields{
-		"status": response.Status,
-		"url":    socketURL.String(),
-	}).Info("Websocket connection established")
+	log.WithFields(log.Fields{"status": response.Status, "url": socketURL.String()}).
+		Info("Websocket connection established")
 
 	return &ChromeWebSocket{conn: websocket}, nil
 }

--- a/tot/tab.tabber.go
+++ b/tot/tab.tabber.go
@@ -6,6 +6,7 @@ import (
 
 	errs "github.com/bdlm/errors"
 	"github.com/bdlm/log"
+	"github.com/mkenney/go-chrome/codes"
 	"github.com/mkenney/go-chrome/tot/socket"
 )
 
@@ -20,7 +21,7 @@ func (chrome *Chrome) NewTab(uri string) (*Tab, error) {
 	}
 	targetURL, err := url.Parse(uri)
 	if nil != err {
-		return nil, errs.Wrap(err, 0, "invalid URL")
+		return nil, errs.Wrap(err, codes.TabURLInvalid, "invalid URL")
 	}
 
 	tab := &Tab{
@@ -35,12 +36,12 @@ func (chrome *Chrome) NewTab(uri string) (*Tab, error) {
 		tab.data,
 	)
 	if nil != err {
-		return nil, errs.Wrap(err, 0, fmt.Sprintf("/new?%s query failed", url.QueryEscape(uri)))
+		return nil, errs.Wrap(err, codes.TabQueryFailed, fmt.Sprintf("/new?%s query failed", url.QueryEscape(uri)))
 	}
 
 	websocketURL, err := url.Parse(tab.Data().WebSocketDebuggerURL)
 	if nil != err {
-		return nil, errs.Wrap(err, 0, fmt.Sprintf("invalid websocket URL '%s'", tab.Data().WebSocketDebuggerURL))
+		return nil, errs.Wrap(err, codes.TabWebsocketURLInvalid, fmt.Sprintf("invalid websocket URL '%s'", tab.Data().WebSocketDebuggerURL))
 	}
 
 	socket := socket.New(websocketURL)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please make sure you view the 
contribution guidelines and fill out the fields below.
-->

### Change type

What types of changes does your code introduce to `go-chrome`?
<!--
Put an `x` in all the boxes that apply
-->

* [x] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Other (please explain here)

This changes the `Socketer` interface, removing the `error` return value from the `Stop` method and adding an `Errors` method that returns an `error` channel.

### Checklist
<!--
Put an `x` in all the boxes that apply. If you're unsure about any of them, don't hesitate to ask.
-->

* [x] I have read the [CONTRIBUTING](https://github.com/mkenney/go-chrome/blob/master/CONTRIBUTING.md) guidelines.
* [x] Lint and unit tests pass locally with my changes.
* [ ] I have created tests which fail without the change (if possible) and prove my fix is effective or that my feature works.
* [x] I have added necessary documentation (if appropriate).

### What does this implement/fix? Please explain these changes.

* recovers from websocket panics produced in the `github.com/gorilla/websocket` package
* provides an `error` channel for accessing errors in the socket listener
* adds initial error codes

### Does this close any currently open issues?
<!--
If so, please link to them here.
-->

#124 

### Any relevant logs, error output, etc?
<!--
If it’s long, please paste to https://pastebin.com/ or similar and insert the link here.
-->

```
error 2018-09-23T20:28:42.226-06:00 nil response from socket
   ⇢  socketID=1
   ⇢  socket.socketer.go:344 github.com/mkenney/go-chrome/tot/socket.(*Socket).listen
error 2018-09-23T20:28:42.226-06:00 Unknown response from web socket
   ⇢  data="{\\\"error\\\":null,\\\"id\\\":0,\\\"method\\\":\\\"\\\",\\\"params\\\":null,\\\"result\\\":null}" method="" responseID=0 socketID=1
   ⇢  socket.socketer.go:368 github.com/mkenney/go-chrome/tot/socket.(*Socket).listen
error 2018-09-23T20:28:43.228-06:00 2000: An unknown error occurred
   ⇢  error="recovered from panic in Socket.listen()"
   ⇢  socket.socketer.go:315 github.com/mkenney/go-chrome/tot/socket.(*Socket).listen.func1
#0: `github.com/mkenney/go-chrome/tot/socket.(*Socket).listen.func1`
        error:   recovered from panic in Socket.listen()
        line:    socket.socketer.go:309
        code:    2000: A panic occurred while reading from a websocket
        message: 2000: An unknown error occurred
```

### Any other comments?


